### PR TITLE
VPN Up Script Grabs Wrong IP

### DIFF
--- a/client-tools/vpn-up
+++ b/client-tools/vpn-up
@@ -79,7 +79,9 @@ while [ -z "$IP" ] || [ "$IP" == 'null' ]
 do
 DROPLET="$(curl -s -X GET -H "Authorization: Bearer $TOKEN" \
     https://api.digitalocean.com/v2/droplets/"$ID")"
-IP="$(echo "$DROPLET" | jq -r '.droplet.networks.v4[0].ip_address')"
+# the following was modified to iterate through a list of IP addresses to find an array element
+# with "type":"public" and then select the ip address from that element     -@kindaran
+IP="$(echo "$DROPLET" | jq -r '.droplet.networks.v4[] | select(.type=="public") | .ip_address')"
 sleep 1
 echo -n "."
 done


### PR DESCRIPTION
Closes #21 

Modify how an IP address is selected from the DO payload. DO provides an array of IP addresses at droplet.networks.v4[]. There are currently two elements that have different "type" values: private and public. The public value is the appropriate IP address to retrieve. 

Therefore the jq expression was modified to first return the entire v4 array, second "search" for an array element that has the key:value pair "type":"public" and return that element, third select the "ip_address" key value from that element.

Output from shellcheck below. The output shown existed prior to making my change. The output did not change after my edit.
```
In vpn-up line 62:
",\"region\":\"$REGION\""\
                         ^-- SC2140: Word is of the form "A"B"C" (B indicated). Did you mean "ABC" or "A\"B\"C"?


In vpn-up line 63:
",\"ssh_keys\":[$KEYS]"\
                       ^-- SC2140: Word is of the form "A"B"C" (B indicated). Did you mean "ABC" or "A\"B\"C"?


In vpn-up line 125:
read
^--^ SC2162: read without -r will mangle backslashes.

For more information:
  https://www.shellcheck.net/wiki/SC2140 -- Word is of the form "A"B"C" (B in...
  https://www.shellcheck.net/wiki/SC2162 -- read without -r will mangle backs...
```
