### PR TITLE
Providing more guidance in the post-install message

### DIFF
--- a/files/etc/update-motd.d/99-getting-started
+++ b/files/etc/update-motd.d/99-getting-started
@@ -17,26 +17,34 @@ cat <<EOF
 hiya! (ن╹◡╹)੭”
 
 NB: OpenVPN and Pi-hole can take several minutes after first boot to be fully
-setup and configured.
+setup and configured. Do NOT reboot the server during this period.
 
-Once initial setup is complete, your client config can be found at:
+You will know initial setup is complete when the following file is present:
 
-    /root/client.ovpn
+    ~/client.ovpn
 
-Securely copy your config to your device and import it into your client app.
+This is your client configuration file. Securely copy it to your device. For
+instance, at the command line of your client, run:
 
-To create an additional client configuration run:
+    scp root@YOUR_DROPLET_IP_ADDRESS:client.ovpn .
 
-    /root/create-client-config.sh client2
+Using your droplet's IP address. Then import it into your client's OpenVPN app.
+
+To create an additional client configuration, run:
+
+    ~/create-client-config.sh client2
 
 NOTE: Certs are only valid for 90 days, so you will need to delete your
 droplet and create a new one at least once every 3 months. This helps ensure
 you're running the latest software.
 
-To access the Pi-hole dashboard, connect to the VPN and visit: pi.hole/admin.
+To access the Pi-hole dashboard, connect to the VPN and visit:
+
+    http://pi.hole/admin
+
 To set / reset the admin password run:
 
-    pihole -a -p  # Command available after first boot setup is complete
+    pihole -a -p  # Command only available after first boot setup is complete
 
 ヾ(^_^) Happy travels Road Warrior, and if you like this tool, consider
 donating to the authors from which this work is derived:


### PR DESCRIPTION
I ran into a couple of issues when I tried this out:

- When I logged in to my droplet, the server said (above the motd) "Reboot required." When I rebooted, I assume I interrupted the build script, as things never seemed to get set up. So I created a new droplet, ignored the reboot request, and setup happened.
- It was unclear to me initially how I would _know_ when setup was complete. After watching the YouTube demo and knowing for sure what file I was expecting (see next point), I thought it would be helpful to share this with new users.
- Files were being referred to with paths like `/root/...` which made me think they were either at the root of the volume or in a subdir actually called "root." In fact they were just in the home directory. The convention for this is `~/` so I'm suggesting that change.
- A minor change, but the Pihole admin URL was inline with a period at the end which could sometimes lead to a 404 if a user didn't realize the period wasn't part of the actual address, and Firefox in particular has a habit of interpreting gTLDs it doesn't recognize (like `.hole`) as a search attempt if you don't include the protocol. So I shunted it down to the next line and added that.

These are just my suggestions, but as I read this was just a one-off hackathon project for you I thought I'd put it in a PR to make it more actionable than just pointing all these things out in an issue. Feel free to reject parts of the PR if you disagree with my reasoning.

Thanks so much for putting this DO Marketplace app together!